### PR TITLE
Add storage state manager and API client fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 /playwright/.cache/
 allure-report
 allure-results
+storage-states/

--- a/config/environments.json
+++ b/config/environments.json
@@ -1,0 +1,18 @@
+{
+  "dev": {
+    "name": "Development",
+    "baseURL": "https://opensource-demo.orangehrmlive.com",
+    "credentials": {
+      "username": "Admin",
+      "password": "admin123"
+    }
+  },
+  "qa": {
+    "name": "Quality Assurance",
+    "baseURL": "https://opensource-demo.orangehrmlive.com",
+    "credentials": {
+      "username": "qa.user",
+      "password": "SuperSecretPassword!"
+    }
+  }
+}

--- a/framework/config/environment.ts
+++ b/framework/config/environment.ts
@@ -1,0 +1,31 @@
+import environments from '../../config/environments.json';
+
+export interface EnvironmentCredentials {
+  username: string;
+  password: string;
+}
+
+export interface EnvironmentConfig {
+  name: string;
+  baseURL: string;
+  credentials: EnvironmentCredentials;
+}
+
+type EnvironmentKey = keyof typeof environments;
+
+export function getEnvironmentConfig(environmentName: string): EnvironmentConfig {
+  const normalisedName = environmentName.toLowerCase() as EnvironmentKey;
+
+  if (!Object.prototype.hasOwnProperty.call(environments, normalisedName)) {
+    const availableEnvs = Object.keys(environments).join(', ');
+    throw new Error(
+      `Unknown environment "${environmentName}". Available options are: ${availableEnvs}.`
+    );
+  }
+
+  return environments[normalisedName];
+}
+
+export function getAvailableEnvironments(): string[] {
+  return Object.keys(environments);
+}

--- a/framework/utils/apiClient.ts
+++ b/framework/utils/apiClient.ts
@@ -1,0 +1,122 @@
+import type { APIRequestContext, APIResponse } from '@playwright/test';
+
+type QueryOptions = NonNullable<Parameters<APIRequestContext['get']>[1]>;
+type DeleteOptions = NonNullable<Parameters<APIRequestContext['delete']>[1]>;
+type MutationOptions = NonNullable<Parameters<APIRequestContext['post']>[1]>;
+
+export class ApiClient {
+  constructor(private readonly request: APIRequestContext, private readonly baseURL: string) {}
+
+  async get<TResponse = unknown>(endpoint: string, options?: QueryOptions): Promise<TResponse> {
+    const response = await this.request.get(this.resolveUrl(endpoint), options);
+    return this.parseResponse<TResponse>(response, 'GET', endpoint);
+  }
+
+  async delete<TResponse = unknown>(endpoint: string, options?: DeleteOptions): Promise<TResponse> {
+    const response = await this.request.delete(this.resolveUrl(endpoint), options);
+    return this.parseResponse<TResponse>(response, 'DELETE', endpoint);
+  }
+
+  async post<TResponse = unknown, TBody = unknown>(
+    endpoint: string,
+    body?: TBody,
+    options?: MutationOptions
+  ): Promise<TResponse> {
+    const response = await this.request.post(
+      this.resolveUrl(endpoint),
+      this.mergeBody(options, body)
+    );
+    return this.parseResponse<TResponse>(response, 'POST', endpoint);
+  }
+
+  async put<TResponse = unknown, TBody = unknown>(
+    endpoint: string,
+    body?: TBody,
+    options?: MutationOptions
+  ): Promise<TResponse> {
+    const response = await this.request.put(
+      this.resolveUrl(endpoint),
+      this.mergeBody(options, body)
+    );
+    return this.parseResponse<TResponse>(response, 'PUT', endpoint);
+  }
+
+  async patch<TResponse = unknown, TBody = unknown>(
+    endpoint: string,
+    body?: TBody,
+    options?: MutationOptions
+  ): Promise<TResponse> {
+    const response = await this.request.patch(
+      this.resolveUrl(endpoint),
+      this.mergeBody(options, body)
+    );
+    return this.parseResponse<TResponse>(response, 'PATCH', endpoint);
+  }
+
+  async head(endpoint: string, options?: QueryOptions): Promise<APIResponse> {
+    const response = await this.request.head(this.resolveUrl(endpoint), options);
+    await this.ensureSuccess(response, 'HEAD', endpoint);
+    return response;
+  }
+
+  private resolveUrl(endpoint: string): string {
+    if (/^https?:/i.test(endpoint)) {
+      return endpoint;
+    }
+
+    const trimmed = endpoint.startsWith('/') ? endpoint.slice(1) : endpoint;
+    return `${this.baseURL.replace(/\/?$/, '/')}${trimmed}`;
+  }
+
+  private async parseResponse<T>(response: APIResponse, method: string, endpoint: string): Promise<T> {
+    await this.ensureSuccess(response, method, endpoint);
+
+    if (this.isJson(response)) {
+      return (await response.json()) as T;
+    }
+
+    return (await response.text()) as unknown as T;
+  }
+
+  private async ensureSuccess(response: APIResponse, method: string, endpoint: string): Promise<void> {
+    if (response.ok()) {
+      return;
+    }
+
+    const body = await this.safeBody(response);
+    throw new Error(
+      `${method} ${endpoint} failed with status ${response.status()} ${response.statusText()}\n${body}`
+    );
+  }
+
+  private isJson(response: APIResponse): boolean {
+    const contentType = response.headers()['content-type'];
+    return Boolean(contentType && contentType.includes('application/json'));
+  }
+
+  private mergeBody<TBody>(
+    options: MutationOptions | undefined,
+    body: TBody | undefined
+  ): MutationOptions | undefined {
+    if (body === undefined) {
+      return options;
+    }
+
+    return {
+      ...(options ?? {}),
+      data: body as unknown,
+    } as MutationOptions;
+  }
+
+  private async safeBody(response: APIResponse): Promise<string> {
+    try {
+      if (this.isJson(response)) {
+        return JSON.stringify(await response.json(), null, 2);
+      }
+
+      return await response.text();
+    } catch (error) {
+      return `Unable to read response body: ${String(error)}`;
+    }
+  }
+}

--- a/framework/utils/storageManager.ts
+++ b/framework/utils/storageManager.ts
@@ -1,0 +1,94 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+import type { BrowserContext, Page } from '@playwright/test';
+
+type StoredState = Awaited<ReturnType<BrowserContext['storageState']>>;
+
+export class StorageManager {
+  private readonly storageDir: string;
+  private ensured = false;
+
+  constructor(storageDir = path.resolve(process.cwd(), 'storage-states')) {
+    this.storageDir = storageDir;
+  }
+
+  async saveFromPage(name: string, page: Page): Promise<string> {
+    return this.saveFromContext(name, page.context());
+  }
+
+  async saveFromContext(name: string, context: BrowserContext): Promise<string> {
+    const filePath = await this.ensurePath(name);
+    await context.storageState({ path: filePath });
+    return filePath;
+  }
+
+  async write(name: string, state: StoredState): Promise<string> {
+    const filePath = await this.ensurePath(name);
+    await fs.writeFile(filePath, JSON.stringify(state, null, 2), 'utf-8');
+    return filePath;
+  }
+
+  async read(name: string): Promise<StoredState | undefined> {
+    const filePath = this.resolveFilePath(name);
+    if (!(await this.fileExists(filePath))) {
+      return undefined;
+    }
+
+    const contents = await fs.readFile(filePath, 'utf-8');
+    return JSON.parse(contents) as StoredState;
+  }
+
+  async getPath(name: string): Promise<string | undefined> {
+    const filePath = this.resolveFilePath(name);
+    return (await this.fileExists(filePath)) ? filePath : undefined;
+  }
+
+  async list(): Promise<string[]> {
+    await this.ensureDir();
+    const entries = await fs.readdir(this.storageDir, { withFileTypes: true });
+    return entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith('.json'))
+      .map((entry) => path.resolve(this.storageDir, entry.name));
+  }
+
+  async clear(name?: string): Promise<void> {
+    if (name) {
+      const filePath = this.resolveFilePath(name);
+      await fs.rm(filePath, { force: true });
+      return;
+    }
+
+    await fs.rm(this.storageDir, { recursive: true, force: true });
+    this.ensured = false;
+  }
+
+  private async ensurePath(name: string): Promise<string> {
+    await this.ensureDir();
+    const filePath = this.resolveFilePath(name);
+    await fs.writeFile(filePath, '', { flag: 'a' });
+    return filePath;
+  }
+
+  private async ensureDir(): Promise<void> {
+    if (this.ensured) {
+      return;
+    }
+
+    await fs.mkdir(this.storageDir, { recursive: true });
+    this.ensured = true;
+  }
+
+  private resolveFilePath(name: string): string {
+    const filename = name.endsWith('.json') ? name : `${name}.json`;
+    return path.resolve(this.storageDir, filename);
+  }
+
+  private async fileExists(filePath: string): Promise<boolean> {
+    try {
+      await fs.access(filePath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/framework/utils/testDataManager.ts
+++ b/framework/utils/testDataManager.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { parse } from 'csv-parse/sync';
+
+export type CsvRow = Record<string, string>;
+
+export class TestDataManager {
+  private readonly jsonCache = new Map<string, unknown>();
+  private readonly csvCache = new Map<string, CsvRow[]>();
+
+  readJSON<TData>(relativePath: string): TData {
+    const absolutePath = this.resolvePath(relativePath);
+
+    if (!this.jsonCache.has(absolutePath)) {
+      const fileContents = readFileSync(absolutePath, 'utf-8');
+      this.jsonCache.set(absolutePath, JSON.parse(fileContents));
+    }
+
+    return this.jsonCache.get(absolutePath) as TData;
+  }
+
+  readCSV(relativePath: string): CsvRow[] {
+    const absolutePath = this.resolvePath(relativePath);
+
+    if (!this.csvCache.has(absolutePath)) {
+      const fileContents = readFileSync(absolutePath, 'utf-8');
+      const records = parse(fileContents, {
+        columns: true,
+        skip_empty_lines: true,
+        trim: true,
+      }) as CsvRow[];
+      this.csvCache.set(absolutePath, records);
+    }
+
+    return this.csvCache.get(absolutePath) as CsvRow[];
+  }
+
+  clearCache(): void {
+    this.jsonCache.clear();
+    this.csvCache.clear();
+  }
+
+  private resolvePath(relativePath: string): string {
+    return path.isAbsolute(relativePath)
+      ? relativePath
+      : path.resolve(process.cwd(), relativePath);
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig, devices } from '@playwright/test';
+import { getEnvironmentConfig } from './framework/config/environment';
 
 /**
  * Read environment variables from file.
@@ -9,6 +10,9 @@ import { defineConfig, devices } from '@playwright/test';
 /**
  * See https://playwright.dev/docs/test-configuration.
  */
+const environmentName = process.env.TEST_ENV ?? 'dev';
+const environment = getEnvironmentConfig(environmentName);
+
 export default defineConfig({
   testDir: './tests',
   /* Run tests in files in parallel */
@@ -20,15 +24,20 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: [['html'],['allure-playwright']],
+  reporter: [['html'], ['allure-playwright']],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://127.0.0.1:3000',
+    baseURL: environment.baseURL,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
-    screenshot:'only-on-failure'
+    screenshot: 'only-on-failure',
+  },
+
+  metadata: {
+    environment: environment.name,
+    environmentKey: environmentName,
   },
 
   /* Configure projects for major browsers */

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,3 @@
-
 # Playwright Udemy Course
 
 This is the repository created as part of Playwright Udemy Course
@@ -6,8 +5,48 @@ This is the repository created as part of Playwright Udemy Course
 Udemy Course Link - https://www.udemy.com/course/master-playwright-docker-cucumber-jenkins/
 
 Please enroll in this course to get the full knowledge about this repository
+
+## 🧱 Framework Enhancements
+
+- **Environment aware configuration** – declare reusable environment metadata in `config/environments.json` and switch between them by setting the `TEST_ENV` environment variable before running Playwright. The selected environment is surfaced in the Playwright HTML report metadata.
+- **Reusable test fixtures** – consume the shared fixtures (environment, test data, storage manager, API client) by importing `test`/`expect` from `tests/fixtures/baseTest`. This keeps tests thin and promotes consistent data access patterns.
+- **Centralised test data loading** – leverage `TestDataManager` (`framework/utils/testDataManager.ts`) to cache and serve JSON/CSV assets during a run, avoiding repetitive file IO and parsing logic in every test.
+- **Storage state utilities** – `StorageManager` (`framework/utils/storageManager.ts`) standardises where storage states are kept, offering helpers to persist, fetch, list or clear the JSON snapshots that Playwright creates after authentication.
+- **API client helpers** – `ApiClient` (`framework/utils/apiClient.ts`) builds on Playwright's `request` fixture to provide typed convenience wrappers for JSON CRUD operations with consistent error handling.
+
+```bash
+# Example: execute login test against the QA configuration
+TEST_ENV=qa npx playwright test tests/UITest/loginTest.spec.ts
+```
+
+### Working with storage state
+
+```ts
+import { test } from '../fixtures/baseTest';
+
+test('reuse authentication', async ({ page, storageManager }) => {
+  await page.goto('/');
+  // ...perform login once
+  const statePath = await storageManager.saveFromPage('orange-admin', page);
+
+  // Later in another test file:
+  test.use({ storageState: statePath });
+});
+```
+
+### Calling backend APIs
+
+```ts
+import { test, expect } from '../fixtures/baseTest';
+
+test('verify backend health', async ({ apiClient }) => {
+  const status = await apiClient.get<{ status: string }>('/api/health');
+  expect(status.status).toBe('ok');
+});
+```
+
 ## 🚀 About Me
-I am an experienced Senior Automation Engineer with over 8+ years of expertise in Web automation, Mobile automation, API automation, and Performance testing. 
+I am an experienced Senior Automation Engineer with over 8+ years of expertise in Web automation, Mobile automation, API automation, and Performance testing.
 
 I possess a strong command of programming languages such as Java, JavaScript, Kotlin, Python, and Scala.
 

--- a/tests/UITest/loginTest.spec.ts
+++ b/tests/UITest/loginTest.spec.ts
@@ -1,11 +1,27 @@
-import {test} from '@playwright/test'
+import { expect, test } from '../fixtures/baseTest';
 
-test('Login Test for Orange HRM',async({page})=>{
-    await page.goto('https://opensource-demo.orangehrmlive.com');
-    await page.locator('input[placeholder="Username"]').fill('Admin');
-    await page.locator('input[placeholder="Password"]').fill('admin123');
-    await page.locator('button[type="submit"]').click();
-    await page.locator('.oxd-userdropdown-tab').click();
-    await page.locator('text=Logout').click();
-    await page.close();
-})
+interface OrangeCredentials {
+  validUsername: string;
+  validPassword: string;
+}
+
+test('Login Test for Orange HRM', async ({ page, environment, testDataManager, storageManager }, testInfo) => {
+  const credentials = testDataManager.readJSON<OrangeCredentials>('tests/testData/orangeHRMCredentials.json');
+
+  await page.goto('/');
+  await page.locator('input[placeholder="Username"]').fill(credentials.validUsername);
+  await page.locator('input[placeholder="Password"]').fill(credentials.validPassword);
+  await page.locator('button[type="submit"]').click();
+
+  await expect(page.locator('.oxd-userdropdown-tab')).toBeVisible();
+
+  // Capture the authenticated session so other tests can re-use it without logging in again.
+  await storageManager.saveFromPage('orange-admin', page);
+
+  await page.locator('.oxd-userdropdown-tab').click();
+  await page.locator('text=Logout').click();
+
+  await expect(page).toHaveURL(/auth\/login$/);
+
+  testInfo.annotations.push({ type: 'environment', description: environment.name });
+});

--- a/tests/fixtures/baseTest.ts
+++ b/tests/fixtures/baseTest.ts
@@ -1,0 +1,35 @@
+import { test as base } from '@playwright/test';
+import { getEnvironmentConfig, EnvironmentConfig } from '../../framework/config/environment';
+import { TestDataManager } from '../../framework/utils/testDataManager';
+import { StorageManager } from '../../framework/utils/storageManager';
+import { ApiClient } from '../../framework/utils/apiClient';
+
+type Fixtures = {
+  environment: EnvironmentConfig;
+  testDataManager: TestDataManager;
+  storageManager: StorageManager;
+  apiClient: ApiClient;
+};
+
+export const test = base.extend<Fixtures>({
+  environment: async ({}, use) => {
+    const environmentName = process.env.TEST_ENV ?? 'dev';
+    const environmentConfig = getEnvironmentConfig(environmentName);
+    await use(environmentConfig);
+  },
+  testDataManager: async ({}, use) => {
+    const manager = new TestDataManager();
+    await use(manager);
+    manager.clearCache();
+  },
+  storageManager: async ({}, use) => {
+    const manager = new StorageManager();
+    await use(manager);
+  },
+  apiClient: async ({ request, environment }, use) => {
+    const client = new ApiClient(request, environment.baseURL);
+    await use(client);
+  },
+});
+
+export const expect = test.expect;


### PR DESCRIPTION
## Summary
- introduce a StorageManager utility to persist, read and clean Playwright storage states and ignore the generated snapshots
- add an ApiClient wrapper and surface both utilities through the shared Playwright fixtures for UI and API reuse
- document the new helpers and show capturing a login session in the sample test

## Testing
- npx playwright test tests/UITest/loginTest.spec.ts --project=chromium --reporter=line *(fails: Playwright browsers not installed in the environment)*
- npx playwright install chromium *(fails: browser download blocked by 403 response)*
- npx tsc --noEmit *(fails: pre-existing TypeScript issues in legacy sample tests outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e52519f6788331a3d84e3e2a706162